### PR TITLE
Add dad response prototype script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # AK
+
+Prototype for a Hebrew 'What Would Dad Say?' app.
+
+## Usage
+
+```bash
+python dad_app.py "חזרתי מאוחר" "אשכנזי"
+```
+
+Run without arguments to get a random situation and response.
+

--- a/dad_app.py
+++ b/dad_app.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""Simple script that simulates typical Israeli dad responses."""
+import random
+import sys
+
+RESPONSES = {
+    "חזרתי מאוחר": {
+        "קלאסי": [
+            "למה אין לך שעון?",
+            "זה נראה לך שעה לחזור?"
+        ],
+        "אשכנזי": [
+            "נו, מה יהיה איתך, אבאלה?"
+        ],
+        "מרוקאי": [
+            "אני מחכה לך עם הכפכף!"
+        ]
+    },
+    "ביקשתי עוד כסף": {
+        "קלאסי": [
+            "כסף לא גדל על העצים!",
+            "כשתעבוד תבין..."
+        ],
+        "רוסי": [
+            "מה אתה חושב, אנחנו בבנק?",
+            "אין כסף, תעבוד!"
+        ]
+    }
+}
+
+def get_response(situation: str, style: str = "קלאסי") -> str:
+    styles = RESPONSES.get(situation, {})
+    options = styles.get(style)
+    if not options:  # fallback to any available style or default text
+        options = next(iter(styles.values()), [])
+    if not options:
+        return "אין לי מה להגיד על זה..."
+    return random.choice(options)
+
+
+def main(args: list[str]) -> None:
+    situation = args[1] if len(args) > 1 else random.choice(list(RESPONSES.keys()))
+    style = args[2] if len(args) > 2 else "קלאסי"
+    print(get_response(situation, style))
+
+
+if __name__ == "__main__":
+    main(sys.argv)


### PR DESCRIPTION
## Summary
- add `dad_app.py`, a small script that picks dad responses by situation and style
- document usage in README

## Testing
- `python dad_app.py "חזרתי מאוחר" "מרוקאי"`
- `python dad_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68951781fbd08324b178fad18ca530ec