### PR TITLE
Add monopoly-style Hebrew (RTL) board game UI

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,180 @@
+const boardSpaces = [
+  {
+    title: "התחלה",
+    detail: "נקודת יציאה. קבלו בונוס חייכני כל סיבוב!",
+  },
+  {
+    title: "כיכר האמנים",
+    detail: "עוצרים לקפה וקונים ציוד יצירתי.",
+  },
+  {
+    title: "רחוב החולמים",
+    detail: "השקעה בפרויקט חדשני משלמת בהמשך.",
+  },
+  {
+    title: "תחנת הרכבת",
+    detail: "קופצים במהירות לשכונה הבאה.",
+  },
+  {
+    title: "שוק הלילה",
+    detail: "מוכרים יצירות ומרוויחים מטבעות.",
+  },
+  {
+    title: "פארק העיר",
+    detail: "מנוחה קצרה וזמן לתכנן מהלך.",
+  },
+  {
+    title: "מעבדה טכנולוגית",
+    detail: "מציאת רעיון שמכפיל את ההכנסות.",
+  },
+  {
+    title: "תחנת רדיו",
+    detail: "מבצע פרסום שמביא חברים חדשים.",
+  },
+  {
+    title: "רחוב החלומות",
+    detail: "קונים נכס חדש וצוברים נקודות.",
+  },
+  {
+    title: "כיכר השותפים",
+    detail: "עושים שיתופי פעולה וחותמים על חוזה.",
+  },
+  {
+    title: "מרכז החדשנות",
+    detail: "הזדמנות לשדרוג גדול.",
+  },
+  {
+    title: "בית הקהילה",
+    detail: "תורמים ומשפרים את המוניטין.",
+  },
+  {
+    title: "מוזיאון היצירה",
+    detail: "צוברים השראה לקראת המהלך הבא.",
+  },
+  {
+    title: "תחנת העיצוב",
+    detail: "מעניקים טאץ' חדש למיזם.",
+  },
+  {
+    title: "הנמל",
+    detail: "משלוחים מגיעים בדיוק בזמן.",
+  },
+  {
+    title: "שדרת המנהיגים",
+    detail: "קופצים קדימה עם החלטה אמיצה.",
+  },
+];
+
+const boardGrid = document.getElementById("boardGrid");
+const positionLabel = document.getElementById("positionLabel");
+const dieOneInput = document.getElementById("dieOne");
+const dieTwoInput = document.getElementById("dieTwo");
+const totalMoveInput = document.getElementById("totalMove");
+const moveButton = document.getElementById("moveButton");
+const resetButton = document.getElementById("resetButton");
+const useTotalButton = document.getElementById("useTotal");
+const moveLog = document.getElementById("moveLog");
+
+let currentPosition = 0;
+let moveCount = 0;
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+const renderBoard = () => {
+  boardGrid.innerHTML = "";
+
+  boardSpaces.forEach((space, index) => {
+    const tile = document.createElement("div");
+    tile.className = "tile";
+
+    if (index === currentPosition) {
+      tile.classList.add("active");
+    }
+
+    const title = document.createElement("h4");
+    title.textContent = `${index}. ${space.title}`;
+
+    const detail = document.createElement("p");
+    detail.textContent = space.detail;
+
+    tile.append(title, detail);
+
+    if (index === currentPosition) {
+      const token = document.createElement("span");
+      token.className = "token";
+      token.textContent = "אתם כאן";
+      tile.append(token);
+    }
+
+    boardGrid.append(tile);
+  });
+
+  positionLabel.textContent = currentPosition.toString();
+};
+
+const addLog = (message) => {
+  const entry = document.createElement("li");
+  entry.textContent = message;
+  moveLog.prepend(entry);
+};
+
+const ensureDiceButtons = () => {
+  const diceButtonContainers = document.querySelectorAll(".dice-buttons");
+  diceButtonContainers.forEach((container) => {
+    if (container.children.length) return;
+
+    for (let i = 1; i <= 6; i += 1) {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.textContent = i.toString();
+      button.addEventListener("click", () => {
+        const targetId = container.dataset.target;
+        const input = document.getElementById(targetId);
+        input.value = i.toString();
+      });
+      container.append(button);
+    }
+  });
+};
+
+const movePlayer = (steps, sourceLabel) => {
+  if (Number.isNaN(steps) || steps <= 0) {
+    addLog("אנא הזינו מספר חוקי של צעדים.");
+    return;
+  }
+
+  const previousPosition = currentPosition;
+  currentPosition = (currentPosition + steps) % boardSpaces.length;
+  moveCount += 1;
+
+  addLog(
+    `מהלך ${moveCount}: ${sourceLabel} => התקדמות של ${steps} צעדים (${previousPosition} → ${currentPosition}).`
+  );
+  renderBoard();
+};
+
+moveButton.addEventListener("click", () => {
+  const dieOne = clamp(parseInt(dieOneInput.value, 10) || 0, 1, 6);
+  const dieTwo = clamp(parseInt(dieTwoInput.value, 10) || 0, 1, 6);
+  const total = dieOne + dieTwo;
+  dieOneInput.value = dieOne.toString();
+  dieTwoInput.value = dieTwo.toString();
+  movePlayer(total, `קוביות ${dieOne} ו-${dieTwo}`);
+});
+
+useTotalButton.addEventListener("click", () => {
+  const total = clamp(parseInt(totalMoveInput.value, 10) || 0, 2, 12);
+  totalMoveInput.value = total ? total.toString() : "";
+  movePlayer(total, "סכום ידני");
+});
+
+resetButton.addEventListener("click", () => {
+  currentPosition = 0;
+  moveCount = 0;
+  moveLog.innerHTML = "";
+  addLog("המשחק אופס לנקודת התחלה.");
+  renderBoard();
+});
+
+ensureDiceButtons();
+renderBoard();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="he" dir="rtl">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>משחק קופסה בסגנון מונופול</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="hero">
+      <div>
+        <h1>המסע בעיר</h1>
+        <p>
+          זרקו קוביות אמיתיות, הזינו את התוצאה כאן, והמשחק יזוז לפי המספרים שלכם.
+        </p>
+      </div>
+      <div class="status-card">
+        <p class="status-label">מיקום נוכחי</p>
+        <p class="status-value" id="positionLabel">0</p>
+      </div>
+    </header>
+
+    <main class="layout">
+      <section class="board" aria-label="לוח המשחק">
+        <div class="board-grid" id="boardGrid"></div>
+      </section>
+
+      <section class="panel" aria-label="בקרת קוביות">
+        <h2>כניסה מהירה של קוביות</h2>
+        <p>
+          הכניסו כל קובייה בנפרד או הזינו סכום כולל. בחרו מה שנוח לכם בזמן אמת.
+        </p>
+
+        <div class="dice-inputs">
+          <div class="dice">
+            <label for="dieOne">קובייה ראשונה</label>
+            <div class="dice-field">
+              <input id="dieOne" type="number" min="1" max="6" value="1" />
+              <div class="dice-buttons" data-target="dieOne"></div>
+            </div>
+          </div>
+          <div class="dice">
+            <label for="dieTwo">קובייה שנייה</label>
+            <div class="dice-field">
+              <input id="dieTwo" type="number" min="1" max="6" value="1" />
+              <div class="dice-buttons" data-target="dieTwo"></div>
+            </div>
+          </div>
+        </div>
+
+        <div class="total-input">
+          <label for="totalMove">או הזנת סכום כולל</label>
+          <div class="total-row">
+            <input id="totalMove" type="number" min="2" max="12" placeholder="סכום" />
+            <button id="useTotal" type="button">השתמש בסכום</button>
+          </div>
+        </div>
+
+        <div class="actions">
+          <button id="moveButton" type="button">זוז קדימה</button>
+          <button id="resetButton" type="button" class="ghost">התחל מחדש</button>
+        </div>
+
+        <div class="log" aria-live="polite" aria-atomic="true">
+          <h3>יומן מהלכים</h3>
+          <ul id="moveLog"></ul>
+        </div>
+      </section>
+    </main>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,255 @@
+:root {
+  color-scheme: light;
+  font-family: "Heebo", "Rubik", system-ui, sans-serif;
+  background: #f7f6fb;
+  color: #1b1b25;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+}
+
+.hero {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 24px;
+  padding: 32px 8vw 16px;
+}
+
+.hero h1 {
+  margin: 0 0 8px;
+  font-size: clamp(2rem, 3vw, 3rem);
+}
+
+.hero p {
+  margin: 0;
+  max-width: 520px;
+  line-height: 1.6;
+  color: #3c3c55;
+}
+
+.status-card {
+  background: #ffffff;
+  border-radius: 18px;
+  padding: 16px 24px;
+  min-width: 140px;
+  text-align: center;
+  box-shadow: 0 10px 30px rgba(27, 27, 37, 0.08);
+}
+
+.status-label {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #676785;
+}
+
+.status-value {
+  margin: 8px 0 0;
+  font-size: 2.4rem;
+  font-weight: 700;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  gap: 32px;
+  padding: 16px 8vw 48px;
+}
+
+.board {
+  background: #ffffff;
+  border-radius: 24px;
+  padding: 24px;
+  box-shadow: 0 18px 40px rgba(20, 20, 34, 0.08);
+}
+
+.board-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 16px;
+}
+
+.tile {
+  border-radius: 16px;
+  padding: 14px;
+  background: #f3f1fa;
+  border: 2px solid transparent;
+  min-height: 110px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  transition: border 0.2s ease, transform 0.2s ease;
+}
+
+.tile h4 {
+  margin: 0 0 6px;
+  font-size: 1rem;
+}
+
+.tile p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #5d5d73;
+  line-height: 1.4;
+}
+
+.tile.active {
+  border-color: #6c5ce7;
+  background: #efeefe;
+  transform: translateY(-4px);
+}
+
+.tile .token {
+  align-self: flex-end;
+  background: #6c5ce7;
+  color: #ffffff;
+  border-radius: 999px;
+  padding: 2px 10px;
+  font-size: 0.75rem;
+}
+
+.panel {
+  background: #ffffff;
+  border-radius: 24px;
+  padding: 24px;
+  box-shadow: 0 18px 40px rgba(20, 20, 34, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.panel h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.panel p {
+  margin: 0;
+  color: #4b4b66;
+  line-height: 1.5;
+}
+
+.dice-inputs {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 16px;
+}
+
+.dice label,
+.total-input label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.dice-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.dice-field input,
+.total-row input {
+  border-radius: 12px;
+  border: 1px solid #d6d6e8;
+  padding: 10px 12px;
+  font-size: 1rem;
+}
+
+.dice-buttons {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(32px, 1fr));
+  gap: 6px;
+}
+
+.dice-buttons button,
+.total-row button,
+.actions button {
+  border: none;
+  border-radius: 10px;
+  padding: 8px 10px;
+  font-weight: 600;
+  cursor: pointer;
+  background: #6c5ce7;
+  color: #ffffff;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.dice-buttons button:hover,
+.total-row button:hover,
+.actions button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(108, 92, 231, 0.3);
+}
+
+.total-input {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.total-row {
+  display: flex;
+  gap: 8px;
+}
+
+.actions {
+  display: flex;
+  gap: 12px;
+}
+
+.actions .ghost {
+  background: #e4e2f3;
+  color: #3b3b57;
+}
+
+.log {
+  background: #f9f8fd;
+  border-radius: 16px;
+  padding: 16px;
+}
+
+.log h3 {
+  margin: 0 0 12px;
+  font-size: 1rem;
+}
+
+#moveLog {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 220px;
+  overflow: auto;
+}
+
+#moveLog li {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 8px 10px;
+  font-size: 0.9rem;
+  color: #4a4a63;
+}
+
+@media (max-width: 960px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .hero {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .status-card {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a simple, playable board-game UI where players can physically roll dice and enter the results to move a token on a monopoly-like board.
- Support Hebrew RTL layout and an accessible, modern card-style interface for quick local playtesting.
- Allow fast manual entry of dice values via per-die quick buttons or a total-sum input to match physical dice rolls.

### Description
- Add `index.html`, `styles.css`, and `app.js` implementing a RTL board layout, active-tile highlighting, and a movement log.
- Implement dice inputs with six quick buttons per die and a `use total` flow that clamps values and triggers movement via `movePlayer`.
- Render board tiles dynamically with `renderBoard`, create quick-button UI with `ensureDiceButtons`, and validate input with `clamp`.
- Include controls for moving (`moveButton`), using a manual total (`useTotal`), and resetting the game (`resetButton`).

### Testing
- Served the site locally using `python -m http.server 8000` and confirmed the server started successfully.
- Captured a full-page screenshot by running a Playwright script that opened `http://localhost:8000/index.html`, and the script completed and produced an artifact. 
- No unit tests were added for the static UI; manual/playwright verification was used and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69514e169e0c8324805a187230321923)